### PR TITLE
Making command handlers more explicit

### DIFF
--- a/ex1/done/LibAAS.Contracts/Commands.fs
+++ b/ex1/done/LibAAS.Contracts/Commands.fs
@@ -2,9 +2,17 @@
 module LibAAS.Contracts.Commands
 
 type CommandData = 
-    | LoanItem
-    | ReturnItem
-    | RegisterInventoryItem of Item * Quantity
+    | LoanItem of LoanItem
+    | ReturnItem of ReturnItem
+    | RegisterInventoryItem of RegisterInventoryItem
+
+and LoanItem = unit
+
+and ReturnItem = unit
+
+and RegisterInventoryItem = {
+    Item:Item
+    Quantity:Quantity }
 
 type Command = AggregateId * CommandData
 

--- a/ex1/done/LibAAS.Domain/Inventory.fs
+++ b/ex1/done/LibAAS.Domain/Inventory.fs
@@ -4,15 +4,13 @@ open LibAAS.Contracts
 open LibAAS.Domain.DomainTypes
 open System
 
-let handleAtInit (id, command) = 
-    match command with
-    | RegisterInventoryItem(item, quantity) -> [ItemRegistered(item, quantity)] |> ok
-    | _ -> raise (exn "Implement me")
+let handleAtInit (id, (command:RegisterInventoryItem)) = 
+    [ItemRegistered(command.Item, command.Quantity)] |> ok
 
 let executeCommand state command =
-    match state with
-    | ItemInit -> handleAtInit command
-    | _ -> raise (exn "Implement me")
+    match state, command with
+    | ItemInit, (id, RegisterInventoryItem cmd) -> handleAtInit (id, cmd)
+    | _ -> InvalidState "Inventory" |> fail
 
 let evolveAtInit = function
     | _ -> raise (exn "Implement me")

--- a/ex1/done/LibAAS.Domain/Loan.fs
+++ b/ex1/done/LibAAS.Domain/Loan.fs
@@ -3,16 +3,14 @@ open LibAAS.Contracts
 open LibAAS.Domain.DomainTypes
 open System
 
-let handleAtInit stateGetters ((aggId:AggregateId), commandData) = 
-    match commandData with
-    | _ -> raise (exn "Implement me")
+let handleAtInit stateGetters ((aggId:AggregateId), (commandData:LoanItem)) = 
+    raise (exn "Implement me")
 
-let handleAtCreated data ((aggId:AggregateId), commandData) =
-    match commandData with
-    | _ -> raise (exn "Implement me")
+let handleAtCreated data ((aggId:AggregateId), (commandData:ReturnItem)) =
+    raise (exn "Implement me")
 
-let executeCommand  state stateGetters command =
-    match state with
+let executeCommand state stateGetters command =
+    match state, command with
     | _ -> raise (exn "Implement me")
 
 let evolveAtInit = function

--- a/ex1/done/LibAAS.Tests/InventoryTests.fs
+++ b/ex1/done/LibAAS.Tests/InventoryTests.fs
@@ -17,5 +17,5 @@ module ``When add an item to the inventory`` =
         let qty = Quantity.Create 10
 
         Given defaultPreconditions
-        |> When (aggId, RegisterInventoryItem (item, qty))
+        |> When (aggId, RegisterInventoryItem { Item = item; Quantity =  qty })
         |> Then ([ItemRegistered(item, qty)] |> ok)

--- a/ex1/start/LibAAS.Contracts/Commands.fs
+++ b/ex1/start/LibAAS.Contracts/Commands.fs
@@ -6,6 +6,10 @@ type CommandData =
     | ReturnItem
     | RegisterInventoryItem
 
+and LoanItem = unit
+and ReturnItem = unit
+and RegisterInventoryItem = unit
+
 type Command = AggregateId * CommandData
 
 

--- a/ex1/start/LibAAS.Domain/Inventory.fs
+++ b/ex1/start/LibAAS.Domain/Inventory.fs
@@ -4,12 +4,11 @@ open LibAAS.Contracts
 open LibAAS.Domain.DomainTypes
 open System
 
-let handleAtInit (id, command) = 
-    match command with
-    | _ -> raise (exn "Implement me")
+let handleAtInit (id, (command:RegisterInventoryItem)) = 
+    raise (exn "Implement me")
 
 let executeCommand state command =
-    match state with
+    match state, command with
     | _ -> raise (exn "Implement me")
 
 let evolveAtInit = function

--- a/ex1/start/LibAAS.Domain/Loan.fs
+++ b/ex1/start/LibAAS.Domain/Loan.fs
@@ -3,16 +3,14 @@ open LibAAS.Contracts
 open LibAAS.Domain.DomainTypes
 open System
 
-let handleAtInit stateGetters ((aggId:AggregateId), commandData) = 
-    match commandData with
-    | _ -> raise (exn "Implement me")
+let handleAtInit stateGetters ((aggId:AggregateId), (commandData:LoanItem)) = 
+    raise (exn "Implement me")
 
-let handleAtCreated data ((aggId:AggregateId), commandData) =
-    match commandData with
-    | _ -> raise (exn "Implement me")
+let handleAtCreated data ((aggId:AggregateId), (commandData:ReturnItem)) =
+    raise (exn "Implement me")
 
-let executeCommand  state stateGetters command =
-    match state with
+let executeCommand state stateGetters command =
+    match state, command with
     | _ -> raise (exn "Implement me")
 
 let evolveAtInit = function

--- a/ex2/README.md
+++ b/ex2/README.md
@@ -22,7 +22,7 @@ let ``The item should not be added if the id is not unique``() =
         defaultPreconditions
             with
             presets = [aggId, [ItemRegistered(item, qty)]] }
-    |> When (aggId, RegisterInventoryItem (item, qty))
+    |> When (aggId, RegisterInventoryItem { Item = item; Quantity =  qty })
     |> Then (InvalidState "Inventory" |> fail)
 ```
 
@@ -40,8 +40,8 @@ Update the functions in the `Inventory` module so they look like this:
 
 ```fsharp
 let executeCommand state command =
-    match state with
-    | ItemInit -> handleAtInit command
+    match state, command with
+    | ItemInit, (id, RegisterInventoryItem cmd) -> handleAtInit (id, cmd)
     | _ -> InvalidState "Inventory" |> fail
 
 let evolveAtInit = function

--- a/ex2/done/LibAAS.Contracts/Commands.fs
+++ b/ex2/done/LibAAS.Contracts/Commands.fs
@@ -2,9 +2,18 @@
 module LibAAS.Contracts.Commands
 
 type CommandData = 
-    | LoanItem
-    | ReturnItem
-    | RegisterInventoryItem of Item * Quantity
+    | LoanItem of LoanItem
+    | ReturnItem of ReturnItem
+    | RegisterInventoryItem of RegisterInventoryItem
+
+and LoanItem = unit
+
+and ReturnItem = unit
+
+and RegisterInventoryItem = {
+    Item:Item
+    Quantity:Quantity }
+
 
 type Command = AggregateId * CommandData
 

--- a/ex2/done/LibAAS.Domain/Inventory.fs
+++ b/ex2/done/LibAAS.Domain/Inventory.fs
@@ -4,14 +4,12 @@ open LibAAS.Contracts
 open LibAAS.Domain.DomainTypes
 open System
 
-let handleAtInit (id, command) = 
-    match command with
-    | RegisterInventoryItem(item, quantity) -> [ItemRegistered(item, quantity)] |> ok
-    | _ -> raise (exn "Implement me")
+let handleAtInit (id, (command:RegisterInventoryItem)) = 
+    [ItemRegistered(command.Item, command.Quantity)] |> ok
 
 let executeCommand state command =
-    match state with
-    | ItemInit -> handleAtInit command
+    match state, command with
+    | ItemInit, (id, RegisterInventoryItem cmd) -> handleAtInit (id, cmd)
     | _ -> InvalidState "Inventory" |> fail
 
 let evolveAtInit = function

--- a/ex2/done/LibAAS.Domain/Loan.fs
+++ b/ex2/done/LibAAS.Domain/Loan.fs
@@ -3,16 +3,14 @@ open LibAAS.Contracts
 open LibAAS.Domain.DomainTypes
 open System
 
-let handleAtInit stateGetters ((aggId:AggregateId), commandData) = 
-    match commandData with
-    | _ -> raise (exn "Implement me")
+let handleAtInit stateGetters ((aggId:AggregateId), (commandData:LoanItem)) = 
+    raise (exn "Implement me")
 
-let handleAtCreated data ((aggId:AggregateId), commandData) =
-    match commandData with
-    | _ -> raise (exn "Implement me")
+let handleAtCreated data ((aggId:AggregateId), (commandData:ReturnItem)) =
+    raise (exn "Implement me")
 
-let executeCommand  state stateGetters command =
-    match state with
+let executeCommand state stateGetters command =
+    match state, command with
     | _ -> raise (exn "Implement me")
 
 let evolveAtInit = function

--- a/ex2/done/LibAAS.Tests/InventoryTests.fs
+++ b/ex2/done/LibAAS.Tests/InventoryTests.fs
@@ -17,7 +17,7 @@ module ``When add an item to the inventory`` =
         let qty = Quantity.Create 10
 
         Given defaultPreconditions
-        |> When (aggId, RegisterInventoryItem (item, qty))
+        |> When (aggId, RegisterInventoryItem { Item = item; Quantity =  qty })
         |> Then ([ItemRegistered(item, qty)] |> ok)
 
     [<Fact>]
@@ -33,5 +33,5 @@ module ``When add an item to the inventory`` =
             defaultPreconditions 
                 with 
                 presets = [aggId, [ItemRegistered(item, qty)]] }
-        |> When (aggId, RegisterInventoryItem (item, qty))
+        |> When (aggId, RegisterInventoryItem { Item = item; Quantity =  qty })
         |> Then (InvalidState "Inventory" |> fail)

--- a/ex2/start/LibAAS.Contracts/Commands.fs
+++ b/ex2/start/LibAAS.Contracts/Commands.fs
@@ -2,9 +2,17 @@
 module LibAAS.Contracts.Commands
 
 type CommandData = 
-    | LoanItem
-    | ReturnItem
-    | RegisterInventoryItem of Item * Quantity
+    | LoanItem of LoanItem
+    | ReturnItem of ReturnItem
+    | RegisterInventoryItem of RegisterInventoryItem
+
+and LoanItem = unit
+
+and ReturnItem = unit
+
+and RegisterInventoryItem = {
+    Item:Item
+    Quantity:Quantity }
 
 type Command = AggregateId * CommandData
 

--- a/ex2/start/LibAAS.Domain/Inventory.fs
+++ b/ex2/start/LibAAS.Domain/Inventory.fs
@@ -4,15 +4,13 @@ open LibAAS.Contracts
 open LibAAS.Domain.DomainTypes
 open System
 
-let handleAtInit (id, command) = 
-    match command with
-    | RegisterInventoryItem(item, quantity) -> [ItemRegistered(item, quantity)] |> ok
-    | _ -> raise (exn "Implement me")
+let handleAtInit (id, (command:RegisterInventoryItem)) = 
+    [ItemRegistered(command.Item, command.Quantity)] |> ok
 
 let executeCommand state command =
-    match state with
-    | ItemInit -> handleAtInit command
-    | _ -> raise (exn "Implement me")
+    match state, command with
+    | ItemInit, (id, RegisterInventoryItem cmd) -> handleAtInit (id, cmd)
+    | _ -> InvalidState "Inventory" |> fail
 
 let evolveAtInit = function
     | _ -> raise (exn "Implement me")

--- a/ex2/start/LibAAS.Domain/Loan.fs
+++ b/ex2/start/LibAAS.Domain/Loan.fs
@@ -3,16 +3,14 @@ open LibAAS.Contracts
 open LibAAS.Domain.DomainTypes
 open System
 
-let handleAtInit stateGetters ((aggId:AggregateId), commandData) = 
-    match commandData with
-    | _ -> raise (exn "Implement me")
+let handleAtInit stateGetters ((aggId:AggregateId), (commandData:LoanItem)) = 
+    raise (exn "Implement me")
 
-let handleAtCreated data ((aggId:AggregateId), commandData) =
-    match commandData with
-    | _ -> raise (exn "Implement me")
+let handleAtCreated data ((aggId:AggregateId), (commandData:ReturnItem)) =
+    raise (exn "Implement me")
 
-let executeCommand  state stateGetters command =
-    match state with
+let executeCommand state stateGetters command =
+    match state, command with
     | _ -> raise (exn "Implement me")
 
 let evolveAtInit = function

--- a/ex2/start/LibAAS.Tests/InventoryTests.fs
+++ b/ex2/start/LibAAS.Tests/InventoryTests.fs
@@ -17,5 +17,5 @@ module ``When add an item to the inventory`` =
         let qty = Quantity.Create 10
 
         Given defaultPreconditions
-        |> When (aggId, RegisterInventoryItem (item, qty))
+        |> When (aggId, RegisterInventoryItem { Item = item; Quantity =  qty })
         |> Then ([ItemRegistered(item, qty)] |> ok)

--- a/ex3/done/LibAAS.Contracts/Commands.fs
+++ b/ex3/done/LibAAS.Contracts/Commands.fs
@@ -2,9 +2,22 @@
 module LibAAS.Contracts.Commands
 
 type CommandData = 
-    | LoanItem of LoanId * UserId * ItemId * LibraryId
-    | ReturnItem
-    | RegisterInventoryItem of Item * Quantity
+    | LoanItem of LoanItem
+    | ReturnItem of ReturnItem
+    | RegisterInventoryItem of RegisterInventoryItem
+
+and LoanItem = {
+    Id:LoanId
+    UserId:UserId
+    ItemId:ItemId
+    LibraryId:LibraryId }
+
+and ReturnItem = {
+    Id:LoanId }
+
+and RegisterInventoryItem = {
+    Item:Item
+    Quantity:Quantity }
 
 type Command = AggregateId * CommandData
 

--- a/ex3/done/LibAAS.Domain/Inventory.fs
+++ b/ex3/done/LibAAS.Domain/Inventory.fs
@@ -4,14 +4,12 @@ open LibAAS.Contracts
 open LibAAS.Domain.DomainTypes
 open System
 
-let handleAtInit (id, command) = 
-    match command with
-    | RegisterInventoryItem(item, quantity) -> [ItemRegistered(item, quantity)] |> ok
-    | _ -> raise (exn "Implement me")
+let handleAtInit (id, (command:RegisterInventoryItem)) = 
+    [ItemRegistered(command.Item, command.Quantity)] |> ok
 
 let executeCommand state command =
-    match state with
-    | ItemInit -> handleAtInit command
+    match state, command with
+    | ItemInit, (id, RegisterInventoryItem cmd) -> handleAtInit (id, cmd)
     | _ -> InvalidState "Inventory" |> fail
 
 let evolveAtInit = function

--- a/ex3/done/LibAAS.Tests/InventoryTests.fs
+++ b/ex3/done/LibAAS.Tests/InventoryTests.fs
@@ -17,7 +17,7 @@ module ``When add an item to the inventory`` =
         let qty = Quantity.Create 10
 
         Given defaultPreconditions
-        |> When (aggId, RegisterInventoryItem (item, qty))
+        |> When (aggId, RegisterInventoryItem { Item = item; Quantity =  qty })
         |> Then ([ItemRegistered(item, qty)] |> ok)
 
     [<Fact>]
@@ -33,5 +33,5 @@ module ``When add an item to the inventory`` =
             defaultPreconditions 
                 with 
                 presets = [aggId, [ItemRegistered(item, qty)]] }
-        |> When (aggId, RegisterInventoryItem (item, qty))
+        |> When (aggId, RegisterInventoryItem { Item = item; Quantity =  qty })
         |> Then (InvalidState "Inventory" |> fail)

--- a/ex3/done/LibAAS.Tests/LoanTests.fs
+++ b/ex3/done/LibAAS.Tests/LoanTests.fs
@@ -39,7 +39,7 @@ module ``When loaning an item`` =
         Given {defaultPreconditions
                 with
                     presets = [itemAggId, [ItemRegistered(item, qty)]]}
-        |> When (aggId, LoanItem (loan.LoanId, loan.UserId, loan.ItemId, loan.LibraryId))
+        |> When (aggId, LoanItem { Id = loan.LoanId; UserId = loan.UserId; ItemId = loan.ItemId; LibraryId =  loan.LibraryId })
         |> Then ([ItemLoaned
                     ( loan,
                       LoanDate System.DateTime.Today,
@@ -50,5 +50,5 @@ module ``When loaning an item`` =
         let aggId,loan = createLoanTestData()
 
         Given defaultPreconditions
-        |> When (aggId, LoanItem (loan.LoanId, loan.UserId, loan.ItemId, loan.LibraryId))
+        |> When (aggId, LoanItem { Id = loan.LoanId; UserId = loan.UserId; ItemId = loan.ItemId; LibraryId =  loan.LibraryId })
         |> Then (InvalidItem |> fail)

--- a/ex3/start/LibAAS.Contracts/Commands.fs
+++ b/ex3/start/LibAAS.Contracts/Commands.fs
@@ -2,10 +2,16 @@
 module LibAAS.Contracts.Commands
 
 type CommandData = 
-    | LoanItem
-    | ReturnItem
-    | RegisterInventoryItem of Item * Quantity
+    | LoanItem of LoanItem
+    | ReturnItem of ReturnItem
+    | RegisterInventoryItem of RegisterInventoryItem
+
+and LoanItem = unit
+
+and ReturnItem = unit
+
+and RegisterInventoryItem = {
+    Item:Item
+    Quantity:Quantity }
 
 type Command = AggregateId * CommandData
-
-

--- a/ex3/start/LibAAS.Domain/Inventory.fs
+++ b/ex3/start/LibAAS.Domain/Inventory.fs
@@ -4,14 +4,12 @@ open LibAAS.Contracts
 open LibAAS.Domain.DomainTypes
 open System
 
-let handleAtInit (id, command) = 
-    match command with
-    | RegisterInventoryItem(item, quantity) -> [ItemRegistered(item, quantity)] |> ok
-    | _ -> raise (exn "Implement me")
+let handleAtInit (id, (command:RegisterInventoryItem)) = 
+    [ItemRegistered(command.Item, command.Quantity)] |> ok
 
 let executeCommand state command =
-    match state with
-    | ItemInit -> handleAtInit command
+    match state, command with
+    | ItemInit, (id, RegisterInventoryItem cmd) -> handleAtInit (id, cmd)
     | _ -> InvalidState "Inventory" |> fail
 
 let evolveAtInit = function

--- a/ex3/start/LibAAS.Domain/Loan.fs
+++ b/ex3/start/LibAAS.Domain/Loan.fs
@@ -3,16 +3,14 @@ open LibAAS.Contracts
 open LibAAS.Domain.DomainTypes
 open System
 
-let handleAtInit stateGetters ((aggId:AggregateId), commandData) = 
-    match commandData with
-    | _ -> raise (exn "Implement me")
+let handleAtInit stateGetters ((aggId:AggregateId), (commandData:LoanItem)) = 
+    raise (exn "Implement me")
 
-let handleAtCreated data ((aggId:AggregateId), commandData) =
-    match commandData with
-    | _ -> raise (exn "Implement me")
+let handleAtCreated data ((aggId:AggregateId), (commandData:ReturnItem)) =
+    raise (exn "Implement me")
 
-let executeCommand  state stateGetters command =
-    match state with
+let executeCommand state stateGetters command =
+    match state, command with
     | _ -> raise (exn "Implement me")
 
 let evolveAtInit = function

--- a/ex3/start/LibAAS.Tests/InventoryTests.fs
+++ b/ex3/start/LibAAS.Tests/InventoryTests.fs
@@ -17,7 +17,7 @@ module ``When add an item to the inventory`` =
         let qty = Quantity.Create 10
 
         Given defaultPreconditions
-        |> When (aggId, RegisterInventoryItem (item, qty))
+        |> When (aggId, RegisterInventoryItem { Item = item; Quantity =  qty })
         |> Then ([ItemRegistered(item, qty)] |> ok)
 
     [<Fact>]
@@ -33,5 +33,5 @@ module ``When add an item to the inventory`` =
             defaultPreconditions 
                 with 
                 presets = [aggId, [ItemRegistered(item, qty)]] }
-        |> When (aggId, RegisterInventoryItem (item, qty))
+        |> When (aggId, RegisterInventoryItem { Item = item; Quantity =  qty })
         |> Then (InvalidState "Inventory" |> fail)

--- a/ex4/README.md
+++ b/ex4/README.md
@@ -20,7 +20,7 @@ module ``When returning an item`` =
     let ``the item is returned``() =
         Given { defaultPreconditions with
                     presets = [aggId, (itemLoaned (today().AddDays(1 |> float)))]}
-        |> When (aggId, ReturnItem loan.LoanId)
+        |> When (aggId, ReturnItem { Id = loan.LoanId })
         |> Then ([ItemReturned (loan, (today() |> ReturnDate))] |> ok)
 
     [<Fact>]
@@ -29,7 +29,7 @@ module ``When returning an item`` =
         |> List.map (fun x ->
             Given { defaultPreconditions with
                         presets = [aggId, (itemLoaned (today().AddDays(-x |> float)))]}
-            |> When (aggId, ReturnItem loan.LoanId)
+            |> When (aggId, ReturnItem { Id = loan.LoanId })
             |> Then ([
                         ItemLate (loan, (today() |> ReturnDate), x, Fine (x*100))
                         ] |> ok))

--- a/ex4/done/LibAAS.Contracts/Commands.fs
+++ b/ex4/done/LibAAS.Contracts/Commands.fs
@@ -2,9 +2,22 @@
 module LibAAS.Contracts.Commands
 
 type CommandData = 
-    | LoanItem of LoanId * UserId * ItemId * LibraryId
-    | ReturnItem of LoanId
-    | RegisterInventoryItem of Item * Quantity
+    | LoanItem of LoanItem
+    | ReturnItem of ReturnItem
+    | RegisterInventoryItem of RegisterInventoryItem
+
+and LoanItem = {
+    Id:LoanId
+    UserId:UserId
+    ItemId:ItemId
+    LibraryId:LibraryId }
+
+and ReturnItem = {
+    Id:LoanId }
+
+and RegisterInventoryItem = {
+    Item:Item
+    Quantity:Quantity }
 
 type Command = AggregateId * CommandData
 

--- a/ex4/done/LibAAS.Domain/Inventory.fs
+++ b/ex4/done/LibAAS.Domain/Inventory.fs
@@ -4,14 +4,12 @@ open LibAAS.Contracts
 open LibAAS.Domain.DomainTypes
 open System
 
-let handleAtInit (id, command) = 
-    match command with
-    | RegisterInventoryItem(item, quantity) -> [ItemRegistered(item, quantity)] |> ok
-    | _ -> raise (exn "Implement me")
+let handleAtInit (id, (command:RegisterInventoryItem)) = 
+    [ItemRegistered(command.Item, command.Quantity)] |> ok
 
 let executeCommand state command =
-    match state with
-    | ItemInit -> handleAtInit command
+    match state, command with
+    | ItemInit, (id, RegisterInventoryItem cmd) -> handleAtInit (id, cmd)
     | _ -> InvalidState "Inventory" |> fail
 
 let evolveAtInit = function

--- a/ex4/done/LibAAS.Tests/InventoryTests.fs
+++ b/ex4/done/LibAAS.Tests/InventoryTests.fs
@@ -17,7 +17,7 @@ module ``When add an item to the inventory`` =
         let qty = Quantity.Create 10
 
         Given defaultPreconditions
-        |> When (aggId, RegisterInventoryItem (item, qty))
+        |> When (aggId, RegisterInventoryItem { Item = item; Quantity =  qty })
         |> Then ([ItemRegistered(item, qty)] |> ok)
 
     [<Fact>]
@@ -33,5 +33,5 @@ module ``When add an item to the inventory`` =
             defaultPreconditions 
                 with 
                 presets = [aggId, [ItemRegistered(item, qty)]] }
-        |> When (aggId, RegisterInventoryItem (item, qty))
+        |> When (aggId, RegisterInventoryItem { Item = item; Quantity =  qty })
         |> Then (InvalidState "Inventory" |> fail)

--- a/ex4/done/LibAAS.Tests/LoanTests.fs
+++ b/ex4/done/LibAAS.Tests/LoanTests.fs
@@ -39,7 +39,7 @@ module ``When loaning an item`` =
         Given {defaultPreconditions 
                 with 
                     presets = [itemAggId, [ItemRegistered(item, qty)]]}
-        |> When (aggId, LoanItem (loan.LoanId, loan.UserId, loan.ItemId, loan.LibraryId))
+        |> When (aggId, LoanItem { Id = loan.LoanId; UserId = loan.UserId; ItemId = loan.ItemId; LibraryId =  loan.LibraryId })
         |> Then ([ItemLoaned 
                     ( loan,
                       LoanDate System.DateTime.Today,
@@ -50,7 +50,7 @@ module ``When loaning an item`` =
         let aggId,loan = createLoanTestData()
 
         Given defaultPreconditions
-        |> When (aggId, LoanItem (loan.LoanId, loan.UserId, loan.ItemId, loan.LibraryId))
+        |> When (aggId, LoanItem { Id = loan.LoanId; UserId = loan.UserId; ItemId = loan.ItemId; LibraryId =  loan.LibraryId })
         |> Then (InvalidItem |> fail)
 
 module ``When returning an item`` =
@@ -66,7 +66,7 @@ module ``When returning an item`` =
     let ``the item is returned``() =
         Given { defaultPreconditions with 
                     presets = [aggId, (itemLoaned (today().AddDays(1 |> float)))]}
-        |> When (aggId, ReturnItem loan.LoanId)
+        |> When (aggId, ReturnItem { Id = loan.LoanId })
         |> Then ([ItemReturned (loan, (today() |> ReturnDate))] |> ok)
 
     [<Fact>]
@@ -75,7 +75,7 @@ module ``When returning an item`` =
         |> List.map (fun x ->
             Given { defaultPreconditions with 
                         presets = [aggId, (itemLoaned (today().AddDays(-x |> float)))]}
-            |> When (aggId, ReturnItem loan.LoanId)
+            |> When (aggId, ReturnItem { Id = loan.LoanId })
             |> Then ([
                         ItemLate (loan, (today() |> ReturnDate), x, Fine (x*100))
                         ] |> ok))

--- a/ex4/start/LibAAS.Contracts/Commands.fs
+++ b/ex4/start/LibAAS.Contracts/Commands.fs
@@ -2,9 +2,22 @@
 module LibAAS.Contracts.Commands
 
 type CommandData = 
-    | LoanItem of LoanId * UserId * ItemId * LibraryId
-    | ReturnItem
-    | RegisterInventoryItem of Item * Quantity
+    | LoanItem of LoanItem
+    | ReturnItem of ReturnItem
+    | RegisterInventoryItem of RegisterInventoryItem
+
+and LoanItem = {
+    Id:LoanId
+    UserId:UserId
+    ItemId:ItemId
+    LibraryId:LibraryId }
+
+and ReturnItem = {
+    Id:LoanId }
+
+and RegisterInventoryItem = {
+    Item:Item
+    Quantity:Quantity }
 
 type Command = AggregateId * CommandData
 

--- a/ex4/start/LibAAS.Domain/Inventory.fs
+++ b/ex4/start/LibAAS.Domain/Inventory.fs
@@ -4,14 +4,12 @@ open LibAAS.Contracts
 open LibAAS.Domain.DomainTypes
 open System
 
-let handleAtInit (id, command) = 
-    match command with
-    | RegisterInventoryItem(item, quantity) -> [ItemRegistered(item, quantity)] |> ok
-    | _ -> raise (exn "Implement me")
+let handleAtInit (id, (command:RegisterInventoryItem)) = 
+    [ItemRegistered(command.Item, command.Quantity)] |> ok
 
 let executeCommand state command =
-    match state with
-    | ItemInit -> handleAtInit command
+    match state, command with
+    | ItemInit, (id, RegisterInventoryItem cmd) -> handleAtInit (id, cmd)
     | _ -> InvalidState "Inventory" |> fail
 
 let evolveAtInit = function

--- a/ex4/start/LibAAS.Tests/InventoryTests.fs
+++ b/ex4/start/LibAAS.Tests/InventoryTests.fs
@@ -17,7 +17,7 @@ module ``When add an item to the inventory`` =
         let qty = Quantity.Create 10
 
         Given defaultPreconditions
-        |> When (aggId, RegisterInventoryItem (item, qty))
+        |> When (aggId, RegisterInventoryItem { Item = item; Quantity =  qty })
         |> Then ([ItemRegistered(item, qty)] |> ok)
 
     [<Fact>]
@@ -33,5 +33,5 @@ module ``When add an item to the inventory`` =
             defaultPreconditions 
                 with 
                 presets = [aggId, [ItemRegistered(item, qty)]] }
-        |> When (aggId, RegisterInventoryItem (item, qty))
+        |> When (aggId, RegisterInventoryItem { Item = item; Quantity =  qty })
         |> Then (InvalidState "Inventory" |> fail)

--- a/ex4/start/LibAAS.Tests/LoanTests.fs
+++ b/ex4/start/LibAAS.Tests/LoanTests.fs
@@ -39,7 +39,7 @@ module ``When loaning an item`` =
         Given {defaultPreconditions 
                 with 
                     presets = [itemAggId, [ItemRegistered(item, qty)]]}
-        |> When (aggId, LoanItem (loan.LoanId, loan.UserId, loan.ItemId, loan.LibraryId))
+        |> When (aggId, LoanItem { Id = loan.LoanId; UserId = loan.UserId; ItemId = loan.ItemId; LibraryId =  loan.LibraryId })
         |> Then ([ItemLoaned 
                     ( loan,
                       LoanDate System.DateTime.Today,
@@ -50,5 +50,5 @@ module ``When loaning an item`` =
         let aggId,loan = createLoanTestData()
 
         Given defaultPreconditions
-        |> When (aggId, LoanItem (loan.LoanId, loan.UserId, loan.ItemId, loan.LibraryId))
+        |> When (aggId, LoanItem { Id = loan.LoanId; UserId = loan.UserId; ItemId = loan.ItemId; LibraryId =  loan.LibraryId })
         |> Then (InvalidItem |> fail)


### PR DESCRIPTION
As we discussed, I changed the command handlers.

The command types of the inputs are now explicit so that we cannot pass a command to the wrong handler anymore. (Which adds some safety at compile time)

I also updated the code snippets in the readme files.

